### PR TITLE
Dev

### DIFF
--- a/src/main/scala/MyServer.scala
+++ b/src/main/scala/MyServer.scala
@@ -211,7 +211,7 @@ object myServer extends zio.App {
 
     myHttp
       .run(myHttpRouter.route)
-      .provideSomeLayer[ZEnv](MyLogging.make(("console" -> LogLevel.Trace), ("access" -> LogLevel.Info)))
+      .provideSomeLayer[ZEnv](MyLogging.make(("console" -> LogLevel.Trace), ("access" -> LogLevel.Info )))
       .exitCode
   }
 }

--- a/src/main/scala/logging/LogLevel.scala
+++ b/src/main/scala/logging/LogLevel.scala
@@ -24,5 +24,5 @@ object LogLevel {
   case object Info  extends LogLevel { val level = 3; val render = "info"  }
   case object Debug extends LogLevel { val level = 2; val render = "debug" }
   case object Trace extends LogLevel { val level = 1; val render = "trace" }
-  case object Off   extends LogLevel { val level = 0; val render = "off"   }
+  case object Off   extends LogLevel { val level = 77; val render = "off"   }
 }


### PR DESCRIPTION
Log subsystem:
1.  Optimization: only appropriate level log request go to the queue.
2.  Time stamp take on log creation, instead of log writing.
3.  Bounded ( dropping queue for logs ) - with stress tests some message will exceed queue size and maybe lost.
4.  Log rotation by log file size and number of archived files.